### PR TITLE
use host port specified by environmnet

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,7 +10,7 @@ services:
     #  - "traefik.http.middlewares.shipwrecked-auth.basicauth.users=a:$2y$05$bcQ3LWVkYdUIMUA.O1MOe.MAGfeGnsCvAXb3jPPqPK23MpsSvixdy"
     #  - traefik.http.routers.https-0-gwkso00g48gwsk044owcs4gw-app.entryPoints=https, shipwrecked-auth
     ports:
-      - 9991:9991
+      - ${BIND_PORT:-9991}:9991
     environment:
       - NODE_ENV=production
     deploy:


### PR DESCRIPTION
Use the host port specified by the environment or fallback to 9991. This allows us to specify a particular port for the staging environment.