### PR TITLE
include datetime in login emails for uniqueness

### DIFF
--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -226,7 +226,9 @@ export const opts: NextAuthOptions = {
         // Customize the verification email
         const { host } = new URL(url);
         try {
-          await sendAuthEmail(email, host, url);
+          const date = new Date();
+          const datetime = `[${date.getDate()}/${date.getMonth()}/${date.getFullYear()} - ${date.getHours()}:${date.getMinutes()}] `
+          await sendAuthEmail(email, host, url, datetime);
           metrics.increment("success.send_auth_email", 1);
         } catch (err) {
           metrics.increment("errors.send_auth_email", 1);

--- a/lib/loops.ts
+++ b/lib/loops.ts
@@ -29,13 +29,14 @@ async function sendEmailWithLoops(
     if (!result.success) throw new Error("Failed to send loops email");
 }
 
-export async function sendAuthEmail(targetEmail: string, host: string, signin_url: string) {
+export async function sendAuthEmail(targetEmail: string, host: string, signin_url: string, datetime: string) {
     await sendEmailWithLoops(
         LOOPS_TRANSACTIONAL_SIGNIN_EMAIL_ID!,
         targetEmail,
         {
             "hostname": host,
-            "signin": signin_url
+            "signin": signin_url,
+            "datetime": datetime
         }
     );
 }


### PR DESCRIPTION
fixes an issue where gmail will automatically wrap the emails in a thread when they have the same subject

addresses #200 