### PR TITLE
Sanitize single quotes in Airtable formulas

### DIFF
--- a/app/rsvp/actions.ts
+++ b/app/rsvp/actions.ts
@@ -62,7 +62,7 @@ async function getClientIP(): Promise<string> {
 }
 
 function sanitizeEmail(email: string): string {
-    return email.toLowerCase().replace(/\s+/g, '');
+    return email.toLowerCase().replace(/[\s+']/g, '');
 }
 
 /**


### PR DESCRIPTION
This sanitizes single quotes being passed into an airtable formula [here](https://github.com/hackclub/shipwrecked/blob/main/app/rsvp/actions.ts#L40) thus escaping it.