### PR TITLE
reduce logging in /bay (was very chatty), consolidate project editor/fix access issue

### DIFF
--- a/components/common/ReviewSection.tsx
+++ b/components/common/ReviewSection.tsx
@@ -60,10 +60,6 @@ export default function ReviewSection({
     hoursOverride: undefined
   });
 
-  // Add debugging
-  console.log('ReviewSection received initialFlags:', initialFlags);
-  console.log('ReviewSection received rawHours:', rawHours);
-
   // Update flags when initialFlags changes
   useEffect(() => {
     if (initialFlags) {


### PR DESCRIPTION
Users could edit their 'shipped' and 'viral' project flags by using the redundant project editor accessed with 'E' key.  This disables that, and also enforces metadata flags editable by users to the limited scope that it should be.