### PR TITLE
Fixed decimal step in manually setting hours

### DIFF
--- a/app/admin/projects/page.tsx
+++ b/app/admin/projects/page.tsx
@@ -901,7 +901,7 @@ function AdminProjectsContent() {
                           className="block w-24 rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 text-sm"
                           placeholder="e.g. 10.5"
                           defaultValue={link.hoursOverride?.toString() || ''}
-                          step="0.1"
+                          step="0.01"
                         />
                         <span className="ml-2 text-xs text-gray-500">hours</span>
                       </div>
@@ -1130,7 +1130,7 @@ function AdminProjectsContent() {
                             className="block w-24 rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 text-sm"
                             placeholder="e.g. 10.5"
                             defaultValue={link.hoursOverride?.toString() || ''}
-                            step="0.1"
+                            step="0.01"
                           />
                           <span className="ml-2 text-xs text-gray-500">hours</span>
                         </div>


### PR DESCRIPTION
When setting hours in the Projects section of the admin panel, it only lets you step 0.1 and now you can approve hours with accuracy up to 0.01, so I just fixed that small thing lol.