### PR TITLE
Order by ASC the projects to review

### DIFF
--- a/app/api/review/route.ts
+++ b/app/api/review/route.ts
@@ -28,6 +28,9 @@ export async function GET(request: NextRequest) {
       where: {
         in_review: true,
       },
+      orderBy: {
+        createdAt: 'asc',
+      },
       include: {
         user: {
           select: {


### PR DESCRIPTION
For some reason, reviewers are required to review projects randomly, resulting in lengthy review times.

The commit is simple: make Prisma order by ASC (older first), so the API responses result in an organized first-to-submit system rather than a random one.

That's all, let me know anything.