### PR TITLE
Fix floating-point errors in hour count

### DIFF
--- a/app/api/gallery/route.ts
+++ b/app/api/gallery/route.ts
@@ -101,7 +101,7 @@ export async function GET(request: Request) {
             ? link.hoursOverride
             : (typeof link.rawHours === 'number' ? link.rawHours : 0);
           
-          return sum + effectiveHours;
+          return parseFloat((sum + effectiveHours).toFixed(2));
         }, 
         0
       );


### PR DESCRIPTION
Round every hour count to 2 decimal places (the precision of the source data) and strip extra zeros