### PR TITLE
fix CVE-2025-55182

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "leaflet-rotatedmarker": "^0.2.0",
     "lenis": "^1.2.3",
     "motion": "^12.6.3",
-    "next": "15.4.8",
+    "next": "15.4.9",
     "next-auth": "^4.24.11",
     "nodemailer": "^7.0.3",
     "postcss": "^8.5.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -728,10 +728,10 @@
     "@emnapi/runtime" "^1.4.3"
     "@tybys/wasm-util" "^0.10.0"
 
-"@next/env@15.4.8":
-  version "15.4.8"
-  resolved "https://registry.yarnpkg.com/@next/env/-/env-15.4.8.tgz#f41741d07651958bccb31fb685da0303a9ef1373"
-  integrity sha512-LydLa2MDI1NMrOFSkO54mTc8iIHSttj6R6dthITky9ylXV2gCGi0bHQjVCtLGRshdRPjyh2kXbxJukDtBWQZtQ==
+"@next/env@15.4.9":
+  version "15.4.9"
+  resolved "https://registry.yarnpkg.com/@next/env/-/env-15.4.9.tgz#5caeeaf5f20cf2bf5176444f13d087963159031f"
+  integrity sha512-OYR0RulK5phnbxxzcLE4/ECgfx1PL3EHrDbjyelJ7jauaO+/Qvj5gG8JPMltB51CygC2KrZ0aAfYLjPYjYY17A==
 
 "@next/eslint-plugin-next@15.2.3":
   version "15.2.3"
@@ -3944,12 +3944,12 @@ next-auth@^4.24.11:
     preact-render-to-string "^5.1.19"
     uuid "^8.3.2"
 
-next@15.4.8:
-  version "15.4.8"
-  resolved "https://registry.yarnpkg.com/next/-/next-15.4.8.tgz#0f20a6cad613dc34547fa6519b2d09005ac370ca"
-  integrity sha512-jwOXTz/bo0Pvlf20FSb6VXVeWRssA2vbvq9SdrOPEg9x8E1B27C2rQtvriAn600o9hH61kjrVRexEffv3JybuA==
+next@15.4.9:
+  version "15.4.9"
+  resolved "https://registry.yarnpkg.com/next/-/next-15.4.9.tgz#9204500a9c3cb2b981fb932077abfa66d3ef663f"
+  integrity sha512-/NedNmbiH4Umt/7SohT9VKxEdBt02Lj33xHrukE7d8Li6juT+75sEq4a4U06jggrvdbklKgr78OZEyWZ8XRrtw==
   dependencies:
-    "@next/env" "15.4.8"
+    "@next/env" "15.4.9"
     "@swc/helpers" "0.5.15"
     caniuse-lite "^1.0.30001579"
     postcss "8.4.31"


### PR DESCRIPTION
This PR patches the React RSC vulnerability. You might like to merge it?